### PR TITLE
从声母中删除yu

### DIFF
--- a/pypinyin/__init__.py
+++ b/pypinyin/__init__.py
@@ -48,7 +48,7 @@ else:
 # 单字拼音库
 PINYIN_DICT = pinyin_dict.pinyin_dict.copy()
 # 声母表
-_INITIALS = 'zh,ch,sh,b,p,m,f,d,t,n,l,g,k,h,j,q,x,r,z,c,s,yu,y,w'.split(',')
+_INITIALS = 'zh,ch,sh,b,p,m,f,d,t,n,l,g,k,h,j,q,x,r,z,c,s,y,w'.split(',')
 # 带声调字符与使用数字标识的字符的对应关系，类似： {u'ā': 'a1'}
 PHONETIC_SYMBOL = phonetic_symbol.phonetic_symbol.copy()
 # 所有的带声调字符


### PR DESCRIPTION
yu在声母列表中造成一个Bug：当用“style=pypinyin.STYLE_FINALS_TONE2”时，所有拼音是yu的字（如雨，与，鱼）都没有韵母输出。