### PR TITLE
简化的pypinyin命令行选项

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,7 +1,7 @@
 [bumpversion]
 commit = True
 tag = True
-current_version = 0.25.0
+current_version = 0.26.0
 
 [bumpversion:file:pypinyin/__init__.py]
 

--- a/pypinyin/__init__.py
+++ b/pypinyin/__init__.py
@@ -28,7 +28,7 @@ from pypinyin.core import (     # noqa
 )
 
 __title__ = 'pypinyin'
-__version__ = '0.25.0'
+__version__ = '0.26.0'
 __author__ = 'mozillazg, 闲耘'
 __license__ = 'MIT'
 __copyright__ = 'Copyright (c) 2016 mozillazg, 闲耘'

--- a/pypinyin/runner.py
+++ b/pypinyin/runner.py
@@ -18,7 +18,7 @@ _formal_styles = ['NORMAL', 'TONE', 'TONE2', 'TONE3',
                   'FINALS_TONE', 'FINALS_TONE2', 'FINALS_TONE3',
                   'BOPOMOFO', 'BOPOMOFO_FIRST', 'CYRILLIC', 'CYRILLIC_FIRST']
 _layman_styles = ['zhao', 'zh4ao', 'zha4o', 'zhao4', 'zh', 'z',
-                  'ao', 'ào', 'a4o', 'ao4']
+                  'ao', '4ao', 'a4o', 'ao4']
 _option_styles = _layman_styles + \
                  _formal_styles[len(_layman_styles) - len(_formal_styles):]
 _default_style = _layman_styles[1]

--- a/pypinyin/runner.py
+++ b/pypinyin/runner.py
@@ -13,11 +13,14 @@ from pypinyin import (                                    # noqa
 )
 from pypinyin.compat import PY2
 
-_formal_styles = ['NORMAL', 'TONE', 'TONE2', 'TONE3', 'INITIALS', 'FIRST_LETTER',
-                  'FINALS', 'FINALS_TONE', 'FINALS_TONE2', 'FINALS_TONE3',
+_formal_styles = ['NORMAL', 'TONE', 'TONE2', 'TONE3',
+                  'INITIALS', 'FIRST_LETTER', 'FINALS',
+                  'FINALS_TONE', 'FINALS_TONE2', 'FINALS_TONE3',
                   'BOPOMOFO', 'BOPOMOFO_FIRST', 'CYRILLIC', 'CYRILLIC_FIRST']
-_layman_styles = ['zhao', 'zh4ao', 'zha4o', 'zhao4', 'zh', 'z', 'ao', 'ào', 'a4o', 'ao4']
-_option_styles = _layman_styles + _formal_styles[len(_layman_styles) - len(_formal_styles):]
+_layman_styles = ['zhao', 'zh4ao', 'zha4o', 'zhao4', 'zh', 'z',
+                  'ao', 'ào', 'a4o', 'ao4']
+_option_styles = _layman_styles + \
+                 _formal_styles[len(_layman_styles) - len(_formal_styles):]
 _default_style = _layman_styles[1]
 
 
@@ -32,16 +35,20 @@ def get_parser():
     parser.add_argument('-V', '--version', action='version',
                         version='{0} {1}'.format(__title__, __version__))
     # 要执行的函数名称
-    parser.add_argument('-f', '--func', help='function name (default: "pinyin")',
+    parser.add_argument('-f', '--func',
+                        help='function name (default: "pinyin")',
                         choices=['pinyin', 'slug'],
                         default='pinyin')
     # 拼音风格
-    parser.add_argument('-s', '--style', help='pinyin style (default: "%s")' % _default_style,
+    parser.add_argument('-s', '--style',
+                        help='pinyin style (default: "%s")' % _default_style,
                         choices=_option_styles, default=_default_style)
-    parser.add_argument('-p', '--separator', help='slug separator (default: "-")',
+    parser.add_argument('-p', '--separator',
+                        help='slug separator (default: "-")',
                         default='-')
-    parser.add_argument('-e', '--errors', help=('how to handle none-pinyin string '
-                        '(default: "default")'),
+    parser.add_argument('-e', '--errors',
+                        help=('how to handle none-pinyin string'
+                              ' (default: "default")'),
                         choices=['default', 'ignore', 'replace'],
                         default='default')
     # 输出多音字

--- a/pypinyin/runner.py
+++ b/pypinyin/runner.py
@@ -14,6 +14,14 @@ from pypinyin import (                                    # noqa
 from pypinyin.compat import PY2
 
 
+_formal_styles = ['NORMAL', 'TONE', 'TONE2', 'TONE3', 'INITIALS', 'FIRST_LETTER',
+                  'FINALS', 'FINALS_TONE', 'FINALS_TONE2', 'FINALS_TONE3',
+                  'BOPOMOFO', 'BOPOMOFO_FIRST', 'CYRILLIC', 'CYRILLIC_FIRST']
+_layman_styles = ['zhao', 'zh4ao', 'zha4o', 'zhao4', 'zh', 'z', 'ao', 'ào', 'a4o', 'ao4']
+_option_styles = _layman_styles + _formal_styles[len(_layman_styles) - len(_formal_styles):]
+_default_style = _layman_styles[1]
+
+
 class NullWriter(object):
     """数据流黑洞，类似 linux/unix 下 /dev/null 的效果。"""
     def write(self, string):
@@ -29,16 +37,12 @@ def get_parser():
                         choices=['pinyin', 'slug'],
                         default='pinyin')
     # 拼音风格
-    parser.add_argument('-s', '--style', help='pinyin style (default: "TONE")',
-                        choices=['NORMAL', 'TONE', 'TONE2', 'TONE3',
-                                 'INITIALS', 'FIRST_LETTER', 'FINALS',
-                                 'FINALS_TONE', 'FINALS_TONE2', 'FINALS_TONE3',
-                                 'BOPOMOFO', 'BOPOMOFO_FIRST',
-                                 'CYRILLIC', 'CYRILLIC_FIRST'], default='TONE')
+    parser.add_argument('-s', '--style', help='pinyin style (default: "%s")' % _default_style,
+                        choices=_option_styles, default=_default_style)
     parser.add_argument('-p', '--separator', help='slug separator (default: "-")',
                         default='-')
     parser.add_argument('-e', '--errors', help=('how to handle none-pinyin string '
-                                          '(default: "default")'),
+                        '(default: "default")'),
                         choices=['default', 'ignore', 'replace'],
                         default='default')
     # 输出多音字
@@ -71,7 +75,7 @@ def main():
     else:
         hans = options.hans
     func = globals()[options.func]
-    style = globals()[options.style]
+    style = globals()[_formal_styles[_option_styles.index(options.style)]]
     heteronym = options.heteronym
     separator = options.separator
     errors = options.errors

--- a/pypinyin/runner.py
+++ b/pypinyin/runner.py
@@ -13,7 +13,6 @@ from pypinyin import (                                    # noqa
 )
 from pypinyin.compat import PY2
 
-
 _formal_styles = ['NORMAL', 'TONE', 'TONE2', 'TONE3', 'INITIALS', 'FIRST_LETTER',
                   'FINALS', 'FINALS_TONE', 'FINALS_TONE2', 'FINALS_TONE3',
                   'BOPOMOFO', 'BOPOMOFO_FIRST', 'CYRILLIC', 'CYRILLIC_FIRST']

--- a/pypinyin/runner.py
+++ b/pypinyin/runner.py
@@ -25,24 +25,24 @@ def get_parser():
     parser.add_argument('-V', '--version', action='version',
                         version='{0} {1}'.format(__title__, __version__))
     # 要执行的函数名称
-    parser.add_argument('--func', help='function name (default: "pinyin")',
+    parser.add_argument('-f', '--func', help='function name (default: "pinyin")',
                         choices=['pinyin', 'slug'],
                         default='pinyin')
     # 拼音风格
-    parser.add_argument('--style', help='pinyin style (default: "TONE")',
+    parser.add_argument('-s', '--style', help='pinyin style (default: "TONE")',
                         choices=['NORMAL', 'TONE', 'TONE2', 'TONE3',
                                  'INITIALS', 'FIRST_LETTER', 'FINALS',
                                  'FINALS_TONE', 'FINALS_TONE2', 'FINALS_TONE3',
                                  'BOPOMOFO', 'BOPOMOFO_FIRST',
                                  'CYRILLIC', 'CYRILLIC_FIRST'], default='TONE')
-    parser.add_argument('--separator', help='slug separator (default: "-")',
+    parser.add_argument('-p', '--separator', help='slug separator (default: "-")',
                         default='-')
-    parser.add_argument('--errors', help=('how to handle none-pinyin string '
+    parser.add_argument('-e', '--errors', help=('how to handle none-pinyin string '
                                           '(default: "default")'),
                         choices=['default', 'ignore', 'replace'],
                         default='default')
     # 输出多音字
-    parser.add_argument('--heteronym', help='enable heteronym',
+    parser.add_argument('-m', '--heteronym', help='enable heteronym',
                         action='store_true')
     # 要查询的汉字
     parser.add_argument('hans', help='chinese string')

--- a/tests/test_cmd.py
+++ b/tests/test_cmd.py
@@ -9,7 +9,7 @@ from pypinyin.runner import get_parser
 def test_default():
     options = get_parser().parse_args(['你好'])
     assert options.func == 'pinyin'
-    assert options.style == 'TONE'
+    assert options.style == 'zh4ao'
     assert options.separator == '-'
     assert not options.heteronym
     assert options.hans == '你好'
@@ -18,12 +18,12 @@ def test_default():
 
 def test_custom():
     options = get_parser().parse_args(['--func', 'slug',
-                                       '--style', 'NORMAL',
+                                       '--style', 'zhao',
                                        '--separator', ' ',
                                        '--errors', 'ignore',
                                        '--heteronym', '你好啊'])
     assert options.func == 'slug'
-    assert options.style == 'NORMAL'
+    assert options.style == 'zhao'
     assert options.separator == ' '
     assert options.errors == 'ignore'
     assert options.heteronym


### PR DESCRIPTION
包括2个修改：

- 增加了 short flags：`-f`, `-s`, `-p`（记如part）, `-e`, `-m`（记如multiple，而且是heteronym的最后一个字母）
- 增加了基于范例的“拼音风格”命令行选项，思路见Go版：https://github.com/mozillazg/go-pinyin/pull/19

提出这些调整的原因，一是原命令行较难记忆，二是输起来太费劲了（尤其是在手机上），都可能吓走用户。

BOPOMOFO、CYRILLIC的4个选项，我不懂怎么设计范例，只好照抄。本来还想弄成不区分大小写、有没有下划线都无所谓的，但对于日常使用，这样应该已经挺方便了。