### PR TITLE
Improve handling of empty strings with neutral_tone_with_five

### DIFF
--- a/pypinyin/style/_tone_convert.py
+++ b/pypinyin/style/_tone_convert.py
@@ -545,7 +545,7 @@ def tone3_to_tone2(tone3, v_to_u=False):
 
 def _improve_tone3(tone3, neutral_tone_with_five=False):
     number = _get_number_from_pinyin(tone3)
-    if number is None and neutral_tone_with_five:
+    if number is None and neutral_tone_with_five and tone3 != '':
         tone3 = '{}5'.format(tone3)
     return tone3
 

--- a/tests/contrib/test_tone_convert.py
+++ b/tests/contrib/test_tone_convert.py
@@ -118,6 +118,8 @@ def test_tone_tone3(pinyin, result):
 @mark.parametrize('pinyin,neutral_tone_with_five,result', [
     ['shang', False, 'shang'],
     ['shang', True, 'shang5'],
+    ['', False, ''],
+    ['', True, '']
 ])
 def test_tone_tone3_with_neutral_tone_with_five(
         pinyin, neutral_tone_with_five, result):


### PR DESCRIPTION
## Improve handling of empty strings with neutral_tone_with_five

Currently, the tone number is added to the input even if it's empty:

```python
>>> tone_to_tone3('', neutral_tone_with_five=True)
'5'
```
This change makes the converter return the unchanged string instead.




