### PR TITLE
docs: Fix a few typos

### DIFF
--- a/README_en.rst
+++ b/README_en.rst
@@ -20,7 +20,7 @@ Based on `hotoo/pinyin <https://github.com/hotoo/pinyin>`__
 Characteristics
 ----
 
-* Finds the most fitting pinyin based on phrase occurences.
+* Finds the most fitting pinyin based on phrase occurrences.
 * Has support for characters with two or more readings (heteronyms).
 * Has support for simplified, traditional characters, and zhuyin (also known als bopomofo).
 * Has support for multiple styles of pinyin and zhuyin (e.g. tone conventions).
@@ -155,7 +155,7 @@ For more FAQ:
 Pinyin data
 ---------
 
-* Single charachter pinyin usage `pinyin-data`_ data
+* Single character pinyin usage `pinyin-data`_ data
 * Pinyin usage in phrases `phrase-pinyin-data`_ data
 
 


### PR DESCRIPTION
There are small typos in:
- README_en.rst

Fixes:
- Should read `occurrences` rather than `occurences`.
- Should read `character` rather than `charachter`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md