### PR TITLE
解决#326：使 PyInstaller 在 Windows 下无需手动加 --collect-data pypinyin 就可打包程序

### DIFF
--- a/pypinyin/__pyinstaller/__init__.py
+++ b/pypinyin/__pyinstaller/__init__.py
@@ -1,0 +1,7 @@
+# reference: https://github.com/pyinstaller/hooksample/blob/master/src/pyi_hooksample/__pyinstaller/__init__.py
+
+import os
+
+def get_hook_dirs():
+    return [os.path.dirname(__file__)]
+

--- a/pypinyin/__pyinstaller/hook-pypinyin.py
+++ b/pypinyin/__pyinstaller/hook-pypinyin.py
@@ -1,0 +1,6 @@
+# reference: https://github.com/pyinstaller/hooksample/blob/master/src/pyi_hooksample/__pyinstaller/hook-pyi_hooksample.py
+
+from PyInstaller.utils.hooks import collect_data_files
+
+datas = collect_data_files('pypinyin', excludes=['__pyinstaller'])
+

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,4 +3,4 @@ python_files = test_*.py
 python_classes = Test
 python_functions = test
 addopts = -slv --cov-report term-missing --tb=short --durations=10 --doctest-modules
-norecursedirs = .git __pycache__
+norecursedirs = .git __pycache__ pypinyin/__pyinstaller

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ packages = [
     'pypinyin.seg',
     'pypinyin.style',
     'pypinyin.tools',
+    'pypinyin.__pyinstaller',
 ]
 
 requirements = []
@@ -76,6 +77,9 @@ setup(
     entry_points={
         'console_scripts': [
             'pypinyin = pypinyin.__main__:main',
+        ],
+        'pyinstaller40': [
+            'hook-dirs = pypinyin.__pyinstaller:get_hook_dirs'
         ],
     },
     classifiers=[


### PR DESCRIPTION
按照 [pyinstaller/hooksample 样例](https://github.com/pyinstaller/hooksample/tree/master) 添加 `pypinyin/__pyinstaller`目录，当程序使用了 pypinyin 且在Windows下用 PyInstaller 打包时，其中的 hook 会自动加 `collect_data_files`。
