### PR TITLE
添加中国内地盲文风格

### DIFF
--- a/pypinyin/constants.py
+++ b/pypinyin/constants.py
@@ -101,6 +101,10 @@ class Style(IntEnum):
     WADEGILES = 14
     #: 国语罗马字风格。如：中国 -> ``jong gwo``
     GWOYEU = 15
+    #: 中国内地盲文风格，无声调。如：中国 -> ``⠌⠲ ⠛⠕``
+    BRAILLE_MAINLAND = 16
+    #: 中国内地盲文风格，带声调。如：中国 -> ``⠌⠲⠁ ⠛⠕⠂``
+    BRAILLE_MAINLAND_TONE = 17
 
 
 NORMAL = STYLE_NORMAL = Style.NORMAL

--- a/pypinyin/style/__init__.py
+++ b/pypinyin/style/__init__.py
@@ -71,4 +71,5 @@ def auto_discover():
         wadegiles,
         others,
         gwoyeu,
+        braille_mainland,
     )

--- a/pypinyin/style/braille_mainland.py
+++ b/pypinyin/style/braille_mainland.py
@@ -1,0 +1,97 @@
+# -*- coding: utf-8 -*-
+"""中国内地盲文相关的几个拼音风格实现:
+
+Style.BRAILLE_MAINLAND
+Style.BRAILLE_MAINLAND_TONE
+"""
+from __future__ import unicode_literals
+import re
+
+from pypinyin.constants import Style
+from pypinyin.style import register
+from pypinyin.style._constants import RE_TONE3
+from pypinyin.style._utils import replace_symbol_to_number, replace_symbol_to_no_symbol
+
+BRAILLE_MAINLAND_REPLACE = (
+    (re.compile(r'iu'), 'iou'),
+    (re.compile(r'ui'), 'uei'),
+    (re.compile(r'un'), 'uen'),
+    (re.compile(r'ong'), 'ung'),
+    (re.compile(r'^yi?'), 'i'),
+    (re.compile(r'^wu?'), 'u'),
+    (re.compile(r'y'), 'i'),
+    (re.compile(r'w'), 'u'),
+    (re.compile(r'iu'), 'v'),
+    (re.compile(r'^([jqx])u'), '\\1v'),
+    (re.compile(r'([iuv])n'), '\\1en'),
+    (re.compile(r'^zhi?'), 'Z'),
+    (re.compile(r'^chi?'), 'C'),
+    (re.compile(r'^shi?'), 'S'),
+    (re.compile(r'^([zcsr])i'), '\\1'),
+    (re.compile(r'iang'), '⠭'),
+    (re.compile(r'uang'), '⠶'),
+    (re.compile(r'ueng'), '⠲'),
+    (re.compile(r'iong'), '⠹'),
+    (re.compile(r'ang'), '⠦'),
+    (re.compile(r'eng'), '⠼'),
+    (re.compile(r'uai'), '⠽'),
+    (re.compile(r'iao'), '⠜'),
+    (re.compile(r'iou'), '⠳'),
+    (re.compile(r'ian'), '⠩'),
+    (re.compile(r'uan'), '⠻'),
+    (re.compile(r'van'), '⠯'),
+    (re.compile(r'uen'), '⠒'),
+    (re.compile(r'ing'), '⠡'),
+    (re.compile(r'ong'), '⠲'),
+    (re.compile(r'er'), '⠗'),
+    (re.compile(r'ai'), '⠪'),
+    (re.compile(r'ei'), '⠮'),
+    (re.compile(r'ao'), '⠖'),
+    (re.compile(r'ou'), '⠷'),
+    (re.compile(r'an'), '⠧'),
+    (re.compile(r'en'), '⠴'),
+    (re.compile(r'ia'), '⠫'),
+    (re.compile(r'ua'), '⠿'),
+    (re.compile(r'ie'), '⠑'),
+    (re.compile(r'uo'), '⠕'),
+    (re.compile(r've'), '⠾'),
+    (re.compile(r'ui'), '⠺'),
+    (re.compile(r'in'), '⠣'),
+    (re.compile(r'vn'), '⠸'),
+
+    #(re.compile(r'eh'), 'E'),
+    #(re.compile(r'([iv])e'), '\\1E'),
+)
+
+BRAILLE_MAINLAND_TABLE = dict(zip(
+    'bpmfdtnlgkhjqxZCSrzcsiuvaoe1234',
+    '⠃⠏⠍⠋⠙⠞⠝⠇⠛⠅⠓⠛⠅⠓⠌⠟⠱⠚⠵⠉⠎⠊⠥⠬⠔⠢⠢⠁⠂⠄⠆'
+))
+
+class BrailleMainlandConverter(object):
+    def to_braille_mainland_tone(self, pinyin, **kwargs):
+        # 用数字表示声调
+        pinyin = replace_symbol_to_number(pinyin)
+        # 将声调数字移动到最后
+        pinyin = RE_TONE3.sub(r'\1\3\2', pinyin)
+        for find_re, replace in BRAILLE_MAINLAND_REPLACE:
+            pinyin = find_re.sub(replace, pinyin)
+        pinyin = ''.join(BRAILLE_MAINLAND_TABLE.get(x, x) for x in pinyin)
+        return pinyin
+    
+    
+    def to_braille_mainland(self, pinyin, **kwargs):
+        pinyin = replace_symbol_to_no_symbol(pinyin)
+        for find_re, replace in BRAILLE_MAINLAND_REPLACE:
+            pinyin = find_re.sub(replace, pinyin)
+        pinyin = ''.join(BRAILLE_MAINLAND_TABLE.get(x, x) for x in pinyin)
+        return pinyin
+    
+
+converter = BrailleMainlandConverter()
+register(Style.BRAILLE_MAINLAND_TONE, func=converter.to_braille_mainland_tone)
+register(Style.BRAILLE_MAINLAND, func=converter.to_braille_mainland)
+
+if(__name__=="__main__"):
+    from pypinyin import pinyin, lazy_pinyin, Style
+    pinyin('人人生而自由', style=Style.BRAILLE_MAINLAND)


### PR DESCRIPTION
## PR 描述
添加对中国内地使用的现行盲文的支持。现行盲文是现代标准汉语的一种标音系统。

添加了两种拼音风格：`Style.BRAILLE_MAINLAND`（不带声调）和`Style.BRAILLE_MAINLAND_TONE`（带声调）

示例：
```py
>>> from pypinyin import pinyin, lazy_pinyin, Style
>>> pinyin('中国', style=Style.BRAILLE_MAINLAND)
[['⠌⠲'], ['⠛⠕']]
>>> pinyin('中国', style=Style.BRAILLE_MAINLAND_TONE)
[['⠌⠲⠁'], ['⠛⠕⠂']]
```

参考：https://zh.wikipedia.org/wiki/%E7%8E%B0%E8%A1%8C%E7%9B%B2%E6%96%87

### 局限性
根据[维基百科](https://zh.wikipedia.org/wiki/%E7%8E%B0%E8%A1%8C%E7%9B%B2%E6%96%87#%E6%8B%BC%E6%B3%95%E8%A7%84%E5%88%99)，盲文是否标注声调需要根据上下文及使用场景决定，具有一定的灵活性。这可能超出了pypinyin库的目标，因此没有在本PR中实现。

我是明眼人，本PR可能需要盲人的测试与反馈。

## 待办事项

* [ ] 符合代码规范
* [ ] 单元测试
* [ ] 文档


<!--
感谢你的贡献！❤️

P.S. 麻烦选择 `develop` 分支作为 PR 的目标分支，谢谢~
-->
